### PR TITLE
chore(ci): fix code cove path to upload

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     # Run only if originated from a PR
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download coverage artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,11 +30,24 @@ jobs:
       - name: Get PR number
         run: |
           echo "PR_NUMBER=$(cat ./pr_number)" >> "$GITHUB_ENV"
+      # Checkout codecov.yaml config from master
+      - uses: actions/checkout@v4
+        with:
+          path: master
+          sparse-checkout: |
+            .github/codecov.yaml
+          sparse-checkout-cone-mode: false
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          path: source
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:
+          codecov_yml_path: master/.github/codecov.yaml
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
+          root_dir: source
           override_branch: ${{ github.event.workflow_run.head_branch }}
           override_commit: ${{ github.event.workflow_run.head_sha }}
           override_pr: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
The codecov action need the actual source file when uploading the report. Now we checkout the configuration file from master and the source files from the PR.