### PR TITLE
chore(ci): reorder checkout to prevent cleanup

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,6 +21,16 @@ jobs:
     # Run only if originated from a PR
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      # Checkout codecov.yaml config from master
+      - uses: actions/checkout@v4
+        with:
+          path: master
+          sparse-checkout: |
+            .github/codecov.yaml
+          sparse-checkout-cone-mode: false
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
@@ -30,16 +40,6 @@ jobs:
       - name: Get PR number
         run: |
           echo "PR_NUMBER=$(cat ./pr_number)" >> "$GITHUB_ENV"
-      # Checkout codecov.yaml config from master
-      - uses: actions/checkout@v4
-        with:
-          path: master
-          sparse-checkout: |
-            .github/codecov.yaml
-          sparse-checkout-cone-mode: false
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
When doing a checkout of the repo the directory is cleaned, this will delete also the coverage report needed by the action.