### PR TITLE
refactor(uuid): specify the stream node uuid when using grpc connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"]}
 rand = "0.8.5"
 serde = { version = "1.0.207", features = ["derive"] }
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.10.0", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you want to use environment variables to set up the application, you can set 
 - `ASTARTE_STORE_DIRECTORY`: path to the directory where to store data (e.g., in case of Astarte properties)
 - `ASTARTE_IGNORE_SSL_ERRORS`: boolean stating if SSL errors should be ignored (default: false)
 - `ASTARTE_MSGHUB_ENDPOINT`: endpoint of the Astarte Message Hub instance
+- `ASTARTE_MSGHUB_NODE_ID`: UUID of the Node to connect to the Astarte Message Hub
 
 Instead, if you want to use a configuration file, you must specify its location by using the `ASTARTE_CONFIG_PATH`
 environment variable. The `config.toml` file must contain the following information:
@@ -62,6 +63,7 @@ astarte_ignore_ssl = false
 # gRPC connection to the Astarte Message Hub
 [astarte.grpc]
 endpoint = "http://[::1]:50051"
+node_id = "ASTARTE_MSGHUB_NODE_ID_HERE"
 ```
 
 NOTE: only one of the `[astarte.mqtt]` or `[astarte.grpc]` sections should be specified in the file.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ astarte_ignore_ssl = false
 # gRPC connection to the Astarte Message Hub
 [astarte.grpc]
 endpoint = "http://[::1]:50051"
-node_id = "ASTARTE_MSGHUB_NODE_ID_HERE"
+#node_id = "ASTARTE_MSGHUB_NODE_ID_HERE"
 ```
 
 NOTE: only one of the `[astarte.mqtt]` or `[astarte.grpc]` sections should be specified in the file.
@@ -78,6 +78,7 @@ A detailed description of the fields is depicted below:
   present, the credential secret will be used.
 - `astarte_ignore_ssl`: a flag stating if SSL errors should be ignored when connecting to Astarte.
 - `endpoint`: the endpoint where the Astarte Message Hub instance is listening for new connections.
+- `node_id`: UUID of the Node to connect to the Astarte Message Hub (optional).
 
 Since the application can be configured with a CLI, when [running the application](#build-and-run) you can specify the
 type of connection (`mqtt` or `grpc`) and the path to the `config.toml` file with the `--astarte_connection` (`-c`) and

--- a/astarte-device-conf/config.toml
+++ b/astarte-device-conf/config.toml
@@ -27,3 +27,4 @@ astarte_ignore_ssl = false
 #
 #[astarte.grpc]
 #endpoint = "http://[::1]:50051"
+#node_id = "ASTARTE_MSGHUB_NODE_ID_HERE"

--- a/src/astarte.rs
+++ b/src/astarte.rs
@@ -21,10 +21,12 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use std::{env, io};
 use tracing::{debug, error};
-use uuid::Uuid;
+use uuid::{uuid, Uuid};
 
 const DEVICE_DATASTREAM: &str =
     include_str!("../interfaces/org.astarte-platform.genericsensors.Values.json");
+
+const DEFAULT_STREAM_NODE_ID: Uuid = uuid!("d72a6187-7cf1-44cc-87e8-e991936166dc");
 
 /// Specify which Astarte library use to connect to Astarte
 #[derive(
@@ -101,7 +103,9 @@ impl ConnectionConfigBuilder {
                 self.astarte_connection = Some(con);
 
                 let endpoint = env::var("ASTARTE_MSGHUB_ENDPOINT")?;
-                let node_id = env::var("ASTARTE_MSGHUB_NODE_ID")?.parse::<Uuid>()?;
+                let node_id = env::var("ASTARTE_MSGHUB_NODE_ID")
+                    .map(|s| s.parse::<Uuid>().unwrap_or(DEFAULT_STREAM_NODE_ID))
+                    .unwrap_or(DEFAULT_STREAM_NODE_ID);
 
                 // update the grpc config info
                 self.grpc_config = Some(GrpcConfigBuilder { node_id, endpoint });


### PR DESCRIPTION
Use EVN ASTARTE_MSGHUB_NODE_ID or the toml file to specify the node id of the stream application